### PR TITLE
adding identifier to functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Next, schedule the function of your dreams. Here we schedule the function to exe
 (at (+ 1000 (now)) #(println "hello from the past!") my-pool)
 ```
 
-You may also specify a description for the scheduled task with the optional `:desc` key.
+You may also specify a unique id with the :id key and a description for the scheduled task with the optional `:desc` key.
 
 Another way of achieving the same result is to use `after` which takes a delaty time in ms from now:
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject silasdavis/at-at "1.2.0"
+(defproject silasdavis/at-at "1.2.1"
   :description "Ahead-of-time function scheduler - with serviced pull requests"
   :url "https://github.com/silasdavis/at-at"
   :dependencies [[org.clojure/clojure "1.3.0"]])


### PR DESCRIPTION
Hi,

I missed the possibility to pass in my own identifiers and created a patch to fix that issue. It works for me, but currently I only use the 'at' function, so the others are not tested.
The id is an optional parameter, so backward compability should be retained.
