### PR TITLE
Changed date format to display 24hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Simple ahead-of-time function scheduler. Allows you to schedule the execution of
 This fork was created to service pull requests left unmerged at https://github.com/overtone/at-at, you can pull it in to your leiningen project by adding:
 
 ```clj
-[silasdavis/at-at "1.2.0"]
+[silasdavis/at-at "1.2.1"]
 ```
 
 to your project.clj dependencies. See: https://clojars.org/silasdavis/at-at.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject silasdavis/at-at "1.2.0"
+(defproject silasdavis/at-at "1.2.1"
   :description "Ahead-of-time function scheduler - with serviced pull requests"
   :url "https://github.com/silasdavis/at-at"
   :dependencies [[org.clojure/clojure "1.3.0"]])

--- a/src/overtone/at_at.clj
+++ b/src/overtone/at_at.clj
@@ -10,7 +10,7 @@
 (defn- format-date
   "Format date object as a string such as: 15:23:35s"
   [date]
-  (.format (java.text.SimpleDateFormat. "EEE hh':'mm':'ss's'") date))
+  (.format (java.text.SimpleDateFormat. "EEE HH':'mm':'ss's'") date))
 
 (defmethod print-method PoolInfo
   [obj ^Writer w]


### PR DESCRIPTION
The `format-date` function doc gives `15:23:35s` as an example but this will never be as the format for the hour is `hh` (Hour in am/pm (1-12)). Moreover there's no way to distinguish whether the formatted date is AM or PM. This tiny tweak gives a clear indication of what time of day is represented.
